### PR TITLE
Improve the inputs intake step in the skeleton.

### DIFF
--- a/src/witan/models/model.clj
+++ b/src/witan/models/model.clj
@@ -33,23 +33,28 @@
    {:witan/name :input-resident-popn
     :witan/version "1.0.0"
     :witan/type :input
-    :witan/fn :hh-model/get-resident-popn}
+    :witan/fn :hh-model/get-resident-popn
+    :witan/params {:src ""}}
    {:witan/name :input-institutional-popn
     :witan/version "1.0.0"
     :witan/type :input
-    :witan/fn :hh-model/get-institutional-popn}
+    :witan/fn :hh-model/get-institutional-popn
+    :witan/params {:src ""}}
    {:witan/name :input-household-representative-rates
     :witan/version "1.0.0"
     :witan/type :input
-    :witan/fn :hh-model/get-household-representative-rates}
+    :witan/fn :hh-model/get-household-representative-rates
+    :witan/params {:src ""}}
    {:witan/name :input-vacancy-rates
     :witan/version "1.0.0"
     :witan/type :input
-    :witan/fn :hh-model/get-vacancy-rates}
+    :witan/fn :hh-model/get-vacancy-rates
+    :witan/params {:src ""}}
    {:witan/name :input-second-homes-rates
     :witan/version "1.0.0"
     :witan/type :input
-    :witan/fn :hh-model/get-second-homes-rates}
+    :witan/fn :hh-model/get-second-homes-rates
+    :witan/params {:src ""}}
    ;; Calculation functions
    {:witan/name :calculate-household-popn
     :witan/version "1.0.0"

--- a/test/witan/models/household_test.clj
+++ b/test/witan/models/household_test.clj
@@ -10,7 +10,7 @@
 (deftest validate-models
   (let [library (m/model-library)
         funs    (p/available-fns library)]
-    (testing "Are the model's valid?"
+    (testing "Are the models valid?"
       (doseq [{:keys [catalog metadata workflow]} (p/available-models library)]
         (let [{:keys [witan/name witan/version]} metadata
               model-name (str name " " version)]
@@ -45,20 +45,18 @@
 
 ;; Testing the model can be run by the workspace executor
 ;; Helpers
-(def test-inputs {:input-resident-popn :resident-popn
-                  :input-institutional-popn :institutional-popn
-                  :input-household-rates :household-rates
-                  :input-vacancy-rates :vacancy-rates
-                  :input-second-homes-rates :second-homes-rates})
+(def test-inputs {:input-resident-popn {}
+                  :input-institutional-popn {}
+                  :input-household-representative-rates {}
+                  :input-vacancy-rates {}
+                  :input-second-homes-rates {}})
 
-(defn read-inputs [file schema]
-  {})
+(defn read-inputs [input _ schema]
+  (get test-inputs (:witan/name input)))
 
 (defn add-input-params
   [input]
-  (assoc-in input [:witan/params] {:src ""
-                                   :key (get test-inputs (:witan/name input))
-                                   :fn read-inputs}))
+  (assoc-in input [:witan/params :fn] (partial read-inputs input)))
 
 ;; Test
 (deftest household-workspace-test


### PR DESCRIPTION
When trying to add the calc fns I realised I didn't have the input step right in the model skeleton.
I'd like to merge this branch and re-tag for `model-skeleton`.
